### PR TITLE
Upgrading to Eclipse 2020-06

### DIFF
--- a/de.dlr.sc.virsat.ide.product/virsat_ide.product
+++ b/de.dlr.sc.virsat.ide.product/virsat_ide.product
@@ -63,8 +63,8 @@ This product includes software developed by other open source projects including
    </plugins>
 
    <features>
-      <feature id="org.eclipse.epp.package.rcp.feature" version="4.12.0.qualifier"/>
-      <feature id="org.eclipse.epp.package.common.feature" version="4.12.0.qualifier"/>
+      <feature id="org.eclipse.epp.package.rcp.feature" version="4.16.0.qualifier"/>
+      <feature id="org.eclipse.epp.package.common.feature" version="4.16.0.qualifier"/>
       <feature id="org.eclipse.platform" version="4.12.0.qualifier"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.jdt"/>

--- a/de.dlr.sc.virsat.ide.product/virsat_ide.product
+++ b/de.dlr.sc.virsat.ide.product/virsat_ide.product
@@ -65,7 +65,7 @@ This product includes software developed by other open source projects including
    <features>
       <feature id="org.eclipse.epp.package.rcp.feature" version="4.16.0.qualifier"/>
       <feature id="org.eclipse.epp.package.common.feature" version="4.16.0.qualifier"/>
-      <feature id="org.eclipse.platform" version="4.12.0.qualifier"/>
+      <feature id="org.eclipse.platform" version="4.16.0.qualifier"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.jdt"/>
       <feature id="org.eclipse.pde"/>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -45,9 +45,8 @@
 		<sonar.jacoco.version>0.7.7.201606060606</sonar.jacoco.version>
 
 		<eclipse.simultaneous.release.build>${maven.build.timestamp}</eclipse.simultaneous.release.build>
-	    <eclipse.simultaneous.release.name>2019-06 Release</eclipse.simultaneous.release.name>
-	    <!-- eclipse.simultaneous.release.repository>http://download.eclipse.org/staging/oxygen/</eclipse.simultaneous.release.repository-->
-	    <eclipse.simultaneous.release.repository>http://download.eclipse.org/releases/2019-06/</eclipse.simultaneous.release.repository>
+	    <eclipse.simultaneous.release.name>2020-06 Release</eclipse.simultaneous.release.name>
+	    <eclipse.simultaneous.release.repository>http://download.eclipse.org/releases/2020-06/</eclipse.simultaneous.release.repository>
 	</properties>
 
 	<profiles>


### PR DESCRIPTION
- Updated repository to point to 2020-06 Eclipse Release
- Updated product definition to use 2020-06 features