### PR TITLE
Migration from Java 8 to Java 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,6 +124,18 @@ jobs:
         with:
           build_job: assemble
           build_profile: ${{ steps.build_decision.outputs.build_type }}
+          
+      # --------------------------------------------
+      # Upload SWTBout screenshots to github artifacts
+      # --------------------------------------------
+      - name: Build - Upload Build Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Deployable Applications
+          path: |
+            deploy/**/*.zip
+            deploy/**/*.tar.gz
+          retention-days: 3
      
       # ---------------------------------------------
       # Deploying to github releases

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,8 @@ jobs:
       # --------------------------------------------
       - name: Setup - Prepare OS
         uses: virtualsatellite/ci-actions/ci-setup-action@v5-beta
-        jdk: 11
+        with:
+           jdk: 11
 
       # --------------------------------------------
       # Development and Feature branches

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,7 @@ jobs:
       # Development and Feature branches
       # --------------------------------------------
       - name: Build - Assemble
-        uses: virtualsatellite/ci-actions/ci-maven-simple-build-action@v4
+        uses: virtualsatellite/ci-actions/ci-maven-simple-build-action@v5-beta
         with:
           build_job: assemble
           build_profile: ${{ steps.build_decision.outputs.build_type }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,7 +99,7 @@ jobs:
       # Perform various setup operations
       # --------------------------------------------
       - name: Setup - Prepare OS
-        uses: virtualsatellite/ci-actions/ci-setup-action@v5-beta
+        uses: virtualsatellite/ci-actions/ci-setup-action@v5
         with:
            jdk: 11
 
@@ -120,7 +120,7 @@ jobs:
       # Development and Feature branches
       # --------------------------------------------
       - name: Build - Assemble
-        uses: virtualsatellite/ci-actions/ci-maven-simple-build-action@v5-beta
+        uses: virtualsatellite/ci-actions/ci-maven-simple-build-action@v5
         with:
           build_job: assemble
           build_profile: ${{ steps.build_decision.outputs.build_type }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
   #---------------------------------------------
   verify:
     name: Verify
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     
     steps:
       # --------------------------------------------
@@ -58,7 +58,7 @@ jobs:
   # -----------------------------------------------------
   deploy:
     name: Build, Assemble and Deploy
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     needs: [verify]
     
     steps:
@@ -99,7 +99,8 @@ jobs:
       # Perform various setup operations
       # --------------------------------------------
       - name: Setup - Prepare OS
-        uses: virtualsatellite/ci-actions/ci-setup-action@v4
+        uses: virtualsatellite/ci-actions/ci-setup-action@v5-beta
+        jdk: 11
 
       # --------------------------------------------
       # Development and Feature branches

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -126,7 +126,7 @@ jobs:
           build_profile: ${{ steps.build_decision.outputs.build_type }}
           
       # --------------------------------------------
-      # Upload SWTBout screenshots to github artifacts
+      # Upload deployable applications
       # --------------------------------------------
       - name: Build - Upload Build Artifacts
         uses: actions/upload-artifact@v2

--- a/de.dlr.sc.virsat.ide.branding.feature/feature.xml
+++ b/de.dlr.sc.virsat.ide.branding.feature/feature.xml
@@ -27,7 +27,6 @@ by German Aerospace Center (DLR e.V.)
 
    <requires>
       <import feature="org.eclipse.epp.mpc"/>
-      <import feature="org.eclipse.epp.logging.aeri.feature"/>
       <import feature="org.eclipse.oomph.setup"/>
       <import feature="de.dlr.sc.virsat.ide.license.feature" version="4.14.0.qualifier"/>
       <import feature="de.dlr.sc.virsat.ide.docs.feature" version="4.14.0.qualifier"/>

--- a/de.dlr.sc.virsat.ide.branding.ui/.classpath
+++ b/de.dlr.sc.virsat.ide.branding.ui/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/de.dlr.sc.virsat.ide.branding.ui/.settings/org.eclipse.jdt.core.prefs
+++ b/de.dlr.sc.virsat.ide.branding.ui/.settings/org.eclipse.jdt.core.prefs
@@ -1,7 +1,10 @@
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
-org.eclipse.jdt.core.compiler.compliance=1.8
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=warning
+org.eclipse.jdt.core.compiler.release=enabled
+org.eclipse.jdt.core.compiler.source=11

--- a/de.dlr.sc.virsat.ide.branding.ui/META-INF/MANIFEST.MF
+++ b/de.dlr.sc.virsat.ide.branding.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: VirSat Development IDE based on EPP RCP/RAP Bundle
 Bundle-SymbolicName: de.dlr.sc.virsat.ide.branding.ui;singleton:=true
 Bundle-Version: 4.14.0.qualifier
 Bundle-Vendor: DLR (German Aerospace Center)
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: org.eclipse.platform,
  org.eclipse.equinox.app
 Eclipse-BundleShape: dir

--- a/de.dlr.sc.virsat.ide.product/launch/VirSat IDE Application.launch
+++ b/de.dlr.sc.virsat.ide.product/launch/VirSat IDE Application.launch
@@ -26,7 +26,7 @@
 <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/CDC-1.0%Foundation-1.0"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -console"/>
 <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
-<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dosgi.requiredJavaVersion=1.8 -Xms256m -Xmx1024m"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Dosgi.requiredJavaVersion=11 -Xms256m -Xmx1024m"/>
 <stringAttribute key="pde.version" value="3.3"/>
 <stringAttribute key="product" value="de.dlr.sc.virsat.ide.branding.ui.product"/>
 <stringAttribute key="productFile" value="\de.dlr.sc.modsim.product\product\modsim_template.product"/>

--- a/de.dlr.sc.virsat.ide.product/virsat_ide.product
+++ b/de.dlr.sc.virsat.ide.product/virsat_ide.product
@@ -57,18 +57,18 @@ This product includes software developed by other open source projects including
    <intro introId="org.eclipse.ui.intro.universal"/>
 
    <vm>
-      <linux include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8</linux>
-      <macos include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8</macos>
-      <solaris include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8</solaris>
-      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8</windows>
+      <linux include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</linux>
+      <macos include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</macos>
+      <solaris include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</solaris>
+      <windows include="false">org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11</windows>
    </vm>
 
    <plugins>
    </plugins>
 
    <features>
-      <feature id="org.eclipse.epp.package.rcp.feature"/>
-      <feature id="org.eclipse.epp.package.common.feature"/>
+      <feature id="org.eclipse.epp.package.rcp.feature" version="4.22.0.qualifier"/>
+      <feature id="org.eclipse.epp.package.common.feature" version="4.22.0.qualifier"/>
       <feature id="org.eclipse.platform"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.jdt"/>
@@ -79,23 +79,18 @@ This product includes software developed by other open source projects including
       <feature id="org.eclipse.e4.core.tools.feature" installMode="root"/>
       <feature id="org.eclipse.eclemma.feature" installMode="root"/>
       <feature id="org.eclipse.egit" installMode="root"/>
-      <feature id="org.eclipse.egit.mylyn" installMode="root"/>
+      <feature id="org.eclipse.egit.gitflow.feature" installMode="root"/>
       <feature id="org.eclipse.m2e.feature" installMode="root"/>
+      <feature id="org.eclipse.m2e.pde.feature" installMode="root"/>
+      <feature id="org.eclipse.m2e.lemminx.feature" installMode="root"/>
       <feature id="org.eclipse.m2e.logback.feature" installMode="root"/>
-      <feature id="org.eclipse.mylyn.bugzilla_feature" installMode="root"/>
-      <feature id="org.eclipse.mylyn.context_feature" installMode="root"/>
-      <feature id="org.eclipse.mylyn.gerrit.feature" installMode="root"/>
-      <feature id="org.eclipse.mylyn.git" installMode="root"/>
-      <feature id="org.eclipse.mylyn.hudson" installMode="root"/>
-      <feature id="org.eclipse.mylyn.ide_feature" installMode="root"/>
-      <feature id="org.eclipse.mylyn.java_feature" installMode="root"/>
-      <feature id="org.eclipse.mylyn.pde_feature" installMode="root"/>
-      <feature id="org.eclipse.mylyn.wikitext_feature" installMode="root"/>
+      <feature id="org.eclipse.oomph.setup" installMode="root"/>
       <feature id="org.eclipse.rap.tools.feature" installMode="root"/>
       <feature id="org.eclipse.swtbot.eclipse.gef" installMode="root"/>
       <feature id="org.eclipse.swtbot.eclipse" installMode="root"/>
       <feature id="org.eclipse.swtbot.ide" installMode="root"/>
       <feature id="org.eclipse.wst.xml_ui.feature" installMode="root"/>
+      <feature id="org.eclipse.passage.ldc.feature" installMode="root"/>
       <feature id="de.dlr.sc.virsat.ide.branding.feature" installMode="root"/>
       <feature id="de.dlr.sc.virsat.model.concept.feature" installMode="root"/>
       <feature id="de.dlr.sc.overtarget.feature" installMode="root"/>

--- a/de.dlr.sc.virsat.ide.product/virsat_ide.product
+++ b/de.dlr.sc.virsat.ide.product/virsat_ide.product
@@ -67,9 +67,9 @@ This product includes software developed by other open source projects including
    </plugins>
 
    <features>
-      <feature id="org.eclipse.epp.package.rcp.feature" version="4.16.0.qualifier"/>
-      <feature id="org.eclipse.epp.package.common.feature" version="4.16.0.qualifier"/>
-      <feature id="org.eclipse.platform" version="4.16.0.qualifier"/>
+      <feature id="org.eclipse.epp.package.rcp.feature" version="4.22.0.qualifier"/>
+      <feature id="org.eclipse.epp.package.common.feature" version="4.22.0.qualifier"/>
+      <feature id="org.eclipse.platform"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.jdt"/>
       <feature id="org.eclipse.pde"/>
@@ -79,23 +79,23 @@ This product includes software developed by other open source projects including
       <feature id="org.eclipse.e4.core.tools.feature" installMode="root"/>
       <feature id="org.eclipse.eclemma.feature" installMode="root"/>
       <feature id="org.eclipse.egit" installMode="root"/>
-      <feature id="org.eclipse.egit.mylyn" installMode="root"/>
-      <feature id="org.eclipse.m2e.feature" installMode="root"  version="1.11.0.qualifier"/>
-      <feature id="org.eclipse.m2e.logback.feature" installMode="root"  version="1.11.0.qualifier"/>
+      <feature id="org.eclipse.egit.gitflow.feature" installMode="root"/>
+       <feature id="org.eclipse.egit.mylyn" installMode="root"/>
+      <feature id="org.eclipse.m2e.feature" installMode="root"/>
+      <feature id="org.eclipse.m2e.pde.feature" installMode="root"/>
+      <feature id="org.eclipse.m2e.lemminx.feature" installMode="root"/>
+      <feature id="org.eclipse.m2e.logback.feature" installMode="root"/>
       <feature id="org.eclipse.mylyn.bugzilla_feature" installMode="root"/>
       <feature id="org.eclipse.mylyn.context_feature" installMode="root"/>
       <feature id="org.eclipse.mylyn.gerrit.feature" installMode="root"/>
       <feature id="org.eclipse.mylyn.git" installMode="root"/>
-      <feature id="org.eclipse.mylyn.hudson" installMode="root"/>
-      <feature id="org.eclipse.mylyn.ide_feature" installMode="root"/>
-      <feature id="org.eclipse.mylyn.java_feature" installMode="root"/>
-      <feature id="org.eclipse.mylyn.pde_feature" installMode="root"/>
-      <feature id="org.eclipse.mylyn.wikitext_feature" installMode="root"/>
+      <feature id="org.eclipse.oomph.setup" installMode="root"/>
       <feature id="org.eclipse.rap.tools.feature" installMode="root"/>
       <feature id="org.eclipse.swtbot.eclipse.gef" installMode="root"/>
       <feature id="org.eclipse.swtbot.eclipse" installMode="root"/>
       <feature id="org.eclipse.swtbot.ide" installMode="root"/>
       <feature id="org.eclipse.wst.xml_ui.feature" installMode="root"/>
+      <feature id="org.eclipse.passage.ldc.feature" installMode="root"/>
       <feature id="de.dlr.sc.virsat.ide.branding.feature" installMode="root"/>
       <feature id="de.dlr.sc.virsat.model.concept.feature" installMode="root"/>
       <feature id="de.dlr.sc.overtarget.feature" installMode="root"/>

--- a/de.dlr.sc.virsat.ide.product/virsat_ide.product
+++ b/de.dlr.sc.virsat.ide.product/virsat_ide.product
@@ -80,6 +80,7 @@ This product includes software developed by other open source projects including
       <feature id="org.eclipse.eclemma.feature" installMode="root"/>
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.egit.gitflow.feature" installMode="root"/>
+      <feature id="org.eclipse.egit.mylyn" installMode="root"/>
       <feature id="org.eclipse.m2e.feature" installMode="root"/>
       <feature id="org.eclipse.m2e.pde.feature" installMode="root"/>
       <feature id="org.eclipse.m2e.lemminx.feature" installMode="root"/>

--- a/de.dlr.sc.virsat.ide.product/virsat_ide.product
+++ b/de.dlr.sc.virsat.ide.product/virsat_ide.product
@@ -67,8 +67,8 @@ This product includes software developed by other open source projects including
    </plugins>
 
    <features>
-      <feature id="org.eclipse.epp.package.rcp.feature" version="4.22.0.qualifier"/>
-      <feature id="org.eclipse.epp.package.common.feature" version="4.22.0.qualifier"/>
+      <feature id="org.eclipse.epp.package.rcp.feature" version="4.24.0.qualifier"/>
+      <feature id="org.eclipse.epp.package.common.feature" version="4.24.0.qualifier"/>
       <feature id="org.eclipse.platform"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.jdt"/>

--- a/de.dlr.sc.virsat.ide.product/virsat_ide.product
+++ b/de.dlr.sc.virsat.ide.product/virsat_ide.product
@@ -67,8 +67,8 @@ This product includes software developed by other open source projects including
    </plugins>
 
    <features>
-      <feature id="org.eclipse.epp.package.rcp.feature" version="4.24.0.qualifier"/>
-      <feature id="org.eclipse.epp.package.common.feature" version="4.24.0.qualifier"/>
+      <feature id="org.eclipse.epp.package.rcp.feature" version="4.23.0.qualifier"/>
+      <feature id="org.eclipse.epp.package.common.feature" version="4.23.0.qualifier"/>
       <feature id="org.eclipse.platform"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.jdt"/>

--- a/de.dlr.sc.virsat.ide.product/virsat_ide.product
+++ b/de.dlr.sc.virsat.ide.product/virsat_ide.product
@@ -67,9 +67,9 @@ This product includes software developed by other open source projects including
    </plugins>
 
    <features>
-      <feature id="org.eclipse.epp.package.rcp.feature" version="4.16.0.qualifier"/>
-      <feature id="org.eclipse.epp.package.common.feature" version="4.16.0.qualifier"/>
-      <feature id="org.eclipse.platform" version="4.16.0.qualifier"/>
+      <feature id="org.eclipse.epp.package.rcp.feature"/>
+      <feature id="org.eclipse.epp.package.common.feature"/>
+      <feature id="org.eclipse.platform"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.jdt"/>
       <feature id="org.eclipse.pde"/>
@@ -80,8 +80,8 @@ This product includes software developed by other open source projects including
       <feature id="org.eclipse.eclemma.feature" installMode="root"/>
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.egit.mylyn" installMode="root"/>
-      <feature id="org.eclipse.m2e.feature" installMode="root"  version="1.11.0.qualifier"/>
-      <feature id="org.eclipse.m2e.logback.feature" installMode="root"  version="1.11.0.qualifier"/>
+      <feature id="org.eclipse.m2e.feature" installMode="root"/>
+      <feature id="org.eclipse.m2e.logback.feature" installMode="root"/>
       <feature id="org.eclipse.mylyn.bugzilla_feature" installMode="root"/>
       <feature id="org.eclipse.mylyn.context_feature" installMode="root"/>
       <feature id="org.eclipse.mylyn.gerrit.feature" installMode="root"/>

--- a/de.dlr.sc.virsat.ide.product/virsat_ide.product
+++ b/de.dlr.sc.virsat.ide.product/virsat_ide.product
@@ -80,7 +80,6 @@ This product includes software developed by other open source projects including
       <feature id="org.eclipse.eclemma.feature" installMode="root"/>
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.egit.gitflow.feature" installMode="root"/>
-       <feature id="org.eclipse.egit.mylyn" installMode="root"/>
       <feature id="org.eclipse.m2e.feature" installMode="root"/>
       <feature id="org.eclipse.m2e.pde.feature" installMode="root"/>
       <feature id="org.eclipse.m2e.lemminx.feature" installMode="root"/>

--- a/de.dlr.sc.virsat.ide.product/virsat_ide.product
+++ b/de.dlr.sc.virsat.ide.product/virsat_ide.product
@@ -80,7 +80,6 @@ This product includes software developed by other open source projects including
       <feature id="org.eclipse.eclemma.feature" installMode="root"/>
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.egit.gitflow.feature" installMode="root"/>
-      <feature id="org.eclipse.egit.mylyn" installMode="root"/>
       <feature id="org.eclipse.m2e.feature" installMode="root"/>
       <feature id="org.eclipse.m2e.pde.feature" installMode="root"/>
       <feature id="org.eclipse.m2e.lemminx.feature" installMode="root"/>

--- a/de.dlr.sc.virsat.ide.product/virsat_ide.product
+++ b/de.dlr.sc.virsat.ide.product/virsat_ide.product
@@ -33,7 +33,7 @@ This product includes software developed by other open source projects including
 -showsplash de.dlr.sc.virsat.ide.branding.ui
 --launcher.defaultAction openFile
       </programArgs>
-      <vmArgs>-Dosgi.requiredJavaVersion=1.8
+      <vmArgs>-Dosgi.requiredJavaVersion=11
 -Xms256m
 -Xmx1024m
 -XX:+UseG1GC

--- a/de.dlr.sc.virsat.ide.product/virsat_ide.product
+++ b/de.dlr.sc.virsat.ide.product/virsat_ide.product
@@ -89,6 +89,11 @@ This product includes software developed by other open source projects including
       <feature id="org.eclipse.mylyn.context_feature" installMode="root"/>
       <feature id="org.eclipse.mylyn.gerrit.feature" installMode="root"/>
       <feature id="org.eclipse.mylyn.git" installMode="root"/>
+      <feature id="org.eclipse.mylyn.hudson" installMode="root"/>
+      <feature id="org.eclipse.mylyn.ide_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.java_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.pde_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.wikitext_feature" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
       <feature id="org.eclipse.rap.tools.feature" installMode="root"/>
       <feature id="org.eclipse.swtbot.eclipse.gef" installMode="root"/>

--- a/de.dlr.sc.virsat.ide.product/virsat_ide.product
+++ b/de.dlr.sc.virsat.ide.product/virsat_ide.product
@@ -69,7 +69,7 @@ This product includes software developed by other open source projects including
    <features>
       <feature id="org.eclipse.epp.package.rcp.feature" version="4.16.0.qualifier"/>
       <feature id="org.eclipse.epp.package.common.feature" version="4.16.0.qualifier"/>
-      <feature id="org.eclipse.platform"/>
+      <feature id="org.eclipse.platform" version="4.16.0.qualifier"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.jdt"/>
       <feature id="org.eclipse.pde"/>
@@ -79,12 +79,9 @@ This product includes software developed by other open source projects including
       <feature id="org.eclipse.e4.core.tools.feature" installMode="root"/>
       <feature id="org.eclipse.eclemma.feature" installMode="root"/>
       <feature id="org.eclipse.egit" installMode="root"/>
-      <feature id="org.eclipse.egit.gitflow.feature" installMode="root"/>
       <feature id="org.eclipse.egit.mylyn" installMode="root"/>
-      <feature id="org.eclipse.m2e.feature" installMode="root"/>
-      <feature id="org.eclipse.m2e.pde.feature" installMode="root"/>
-      <feature id="org.eclipse.m2e.lemminx.feature" installMode="root"/>
-      <feature id="org.eclipse.m2e.logback.feature" installMode="root"/>
+      <feature id="org.eclipse.m2e.feature" installMode="root"  version="1.11.0.qualifier"/>
+      <feature id="org.eclipse.m2e.logback.feature" installMode="root"  version="1.11.0.qualifier"/>
       <feature id="org.eclipse.mylyn.bugzilla_feature" installMode="root"/>
       <feature id="org.eclipse.mylyn.context_feature" installMode="root"/>
       <feature id="org.eclipse.mylyn.gerrit.feature" installMode="root"/>
@@ -94,13 +91,11 @@ This product includes software developed by other open source projects including
       <feature id="org.eclipse.mylyn.java_feature" installMode="root"/>
       <feature id="org.eclipse.mylyn.pde_feature" installMode="root"/>
       <feature id="org.eclipse.mylyn.wikitext_feature" installMode="root"/>
-      <feature id="org.eclipse.oomph.setup" installMode="root"/>
       <feature id="org.eclipse.rap.tools.feature" installMode="root"/>
       <feature id="org.eclipse.swtbot.eclipse.gef" installMode="root"/>
       <feature id="org.eclipse.swtbot.eclipse" installMode="root"/>
       <feature id="org.eclipse.swtbot.ide" installMode="root"/>
       <feature id="org.eclipse.wst.xml_ui.feature" installMode="root"/>
-      <feature id="org.eclipse.passage.ldc.feature" installMode="root"/>
       <feature id="de.dlr.sc.virsat.ide.branding.feature" installMode="root"/>
       <feature id="de.dlr.sc.virsat.model.concept.feature" installMode="root"/>
       <feature id="de.dlr.sc.overtarget.feature" installMode="root"/>

--- a/de.dlr.sc.virsat.ide.product/virsat_ide.product
+++ b/de.dlr.sc.virsat.ide.product/virsat_ide.product
@@ -67,8 +67,8 @@ This product includes software developed by other open source projects including
    </plugins>
 
    <features>
-      <feature id="org.eclipse.epp.package.rcp.feature" version="4.22.0.qualifier"/>
-      <feature id="org.eclipse.epp.package.common.feature" version="4.22.0.qualifier"/>
+      <feature id="org.eclipse.epp.package.rcp.feature" version="4.16.0.qualifier"/>
+      <feature id="org.eclipse.epp.package.common.feature" version="4.16.0.qualifier"/>
       <feature id="org.eclipse.platform"/>
       <feature id="org.eclipse.epp.mpc" installMode="root"/>
       <feature id="org.eclipse.jdt"/>
@@ -80,10 +80,20 @@ This product includes software developed by other open source projects including
       <feature id="org.eclipse.eclemma.feature" installMode="root"/>
       <feature id="org.eclipse.egit" installMode="root"/>
       <feature id="org.eclipse.egit.gitflow.feature" installMode="root"/>
+      <feature id="org.eclipse.egit.mylyn" installMode="root"/>
       <feature id="org.eclipse.m2e.feature" installMode="root"/>
       <feature id="org.eclipse.m2e.pde.feature" installMode="root"/>
       <feature id="org.eclipse.m2e.lemminx.feature" installMode="root"/>
       <feature id="org.eclipse.m2e.logback.feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.bugzilla_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.context_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.gerrit.feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.git" installMode="root"/>
+      <feature id="org.eclipse.mylyn.hudson" installMode="root"/>
+      <feature id="org.eclipse.mylyn.ide_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.java_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.pde_feature" installMode="root"/>
+      <feature id="org.eclipse.mylyn.wikitext_feature" installMode="root"/>
       <feature id="org.eclipse.oomph.setup" installMode="root"/>
       <feature id="org.eclipse.rap.tools.feature" installMode="root"/>
       <feature id="org.eclipse.swtbot.eclipse.gef" installMode="root"/>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -45,8 +45,8 @@
 		<sonar.jacoco.version>0.7.7.201606060606</sonar.jacoco.version>
 
 		<eclipse.simultaneous.release.build>${maven.build.timestamp}</eclipse.simultaneous.release.build>
-	    <eclipse.simultaneous.release.name>2020-06 Release</eclipse.simultaneous.release.name>
-	    <eclipse.simultaneous.release.repository>http://download.eclipse.org/releases/2020-06/</eclipse.simultaneous.release.repository>
+		<eclipse.simultaneous.release.name>2021-12 Release</eclipse.simultaneous.release.name>
+		<eclipse.simultaneous.release.repository>http://download.eclipse.org/releases/2021-12/</eclipse.simultaneous.release.repository>
 	</properties>
 
 	<profiles>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -216,7 +216,7 @@
 		
 		<repository>
 			<id>github-mylyn-connector-feature</id>
-			<url>https://download.eclipse.org/egit/github/updates/</url>
+			<url>https://download.eclipse.org/egit/github/updates-nightly/</url>
 			<layout>p2</layout>
 		</repository> 
 	</repositories>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -45,8 +45,8 @@
 		<sonar.jacoco.version>0.7.7.201606060606</sonar.jacoco.version>
 
 		<eclipse.simultaneous.release.build>${maven.build.timestamp}</eclipse.simultaneous.release.build>
-		<eclipse.simultaneous.release.name>2020-06 Release</eclipse.simultaneous.release.name>
-		<eclipse.simultaneous.release.repository>http://download.eclipse.org/releases/2020-06/</eclipse.simultaneous.release.repository>
+		<eclipse.simultaneous.release.name>2021-12 Release</eclipse.simultaneous.release.name>
+		<eclipse.simultaneous.release.repository>http://download.eclipse.org/releases/2021-12/</eclipse.simultaneous.release.repository>
 	</properties>
 
 	<profiles>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -16,7 +16,7 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>1.7.0</tycho-version>
+		<tycho-version>2.6.0</tycho-version>
 		<maven.resources.version>2.6</maven.resources.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -45,8 +45,8 @@
 		<sonar.jacoco.version>0.7.7.201606060606</sonar.jacoco.version>
 
 		<eclipse.simultaneous.release.build>${maven.build.timestamp}</eclipse.simultaneous.release.build>
-	    <eclipse.simultaneous.release.name>2020-06 Release</eclipse.simultaneous.release.name>
-	    <eclipse.simultaneous.release.repository>http://download.eclipse.org/releases/2020-06/</eclipse.simultaneous.release.repository>
+		<eclipse.simultaneous.release.name>2020-06 Release</eclipse.simultaneous.release.name>
+		<eclipse.simultaneous.release.repository>http://download.eclipse.org/releases/2020-06/</eclipse.simultaneous.release.repository>
 	</properties>
 
 	<profiles>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -45,8 +45,8 @@
 		<sonar.jacoco.version>0.7.7.201606060606</sonar.jacoco.version>
 
 		<eclipse.simultaneous.release.build>${maven.build.timestamp}</eclipse.simultaneous.release.build>
-		<eclipse.simultaneous.release.name>2021-12 Release</eclipse.simultaneous.release.name>
-		<eclipse.simultaneous.release.repository>http://download.eclipse.org/releases/2021-12/</eclipse.simultaneous.release.repository>
+		<eclipse.simultaneous.release.name>2022-06 Release</eclipse.simultaneous.release.name>
+		<eclipse.simultaneous.release.repository>http://download.eclipse.org/releases/2022-06/</eclipse.simultaneous.release.repository>
 	</properties>
 
 	<profiles>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -208,6 +208,11 @@
 			<layout>p2</layout>
 		</repository> 
 		
+		<repository>
+			<id>mylyn-feature</id>
+			<url>https://download.eclipse.org/mylyn/releases/3.25/</url>
+			<layout>p2</layout>
+		</repository> 
 	</repositories>
 
 	<build>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -45,8 +45,8 @@
 		<sonar.jacoco.version>0.7.7.201606060606</sonar.jacoco.version>
 
 		<eclipse.simultaneous.release.build>${maven.build.timestamp}</eclipse.simultaneous.release.build>
-		<eclipse.simultaneous.release.name>2021-12 Release</eclipse.simultaneous.release.name>
-		<eclipse.simultaneous.release.repository>http://download.eclipse.org/releases/2021-12/</eclipse.simultaneous.release.repository>
+	    <eclipse.simultaneous.release.name>2020-06 Release</eclipse.simultaneous.release.name>
+	    <eclipse.simultaneous.release.repository>http://download.eclipse.org/releases/2020-06/</eclipse.simultaneous.release.repository>
 	</properties>
 
 	<profiles>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -36,7 +36,7 @@
 		<build.deploy.release>false</build.deploy.release>
 		
 		<!-- OverTarget -->
-		<overtarget.version>1.2.1</overtarget.version>
+		<overtarget.version>1.4.0</overtarget.version>
 
 		<!-- Sonar Code Coverage -->
 		<sonar.core.codeCoveragePlugin>jacoco</sonar.core.codeCoveragePlugin>
@@ -79,7 +79,7 @@
 				<p2.repo.virsat.url>https://sourceforge.net/projects/virtualsatellite/files/VirtualSatellite4-DVLM/development/</p2.repo.virsat.url>
 				<!-- p2.repo.virsat.url>file:/C:/git/VirtualSatellite4-Core/builds/p2/VirSat4_Dvlm_ConceptIDE/development</p2.repo.virsat.url -->
 				<p2.repo.overtarget.id>Overtarget-Feature-Development</p2.repo.overtarget.id>
-				<p2.repo.overtarget.url>https://sourceforge.net/projects/overtarget/files/release/${overtarget.version}/483/</p2.repo.overtarget.url>
+				<p2.repo.overtarget.url>https://sourceforge.net/projects/overtarget/files/release/${overtarget.version}/9014ba468eeed12f9b9624b20bf8feef1f513fdd//</p2.repo.overtarget.url>
 			</properties>
 		</profile>
 		<profile>
@@ -93,7 +93,7 @@
 				<p2.repo.virsat.id>DVLM-Tools-Feature-Integration</p2.repo.virsat.id>
 				<p2.repo.virsat.url>https://sourceforge.net/projects/virtualsatellite/files/VirtualSatellite4-DVLM/integration/${build.version}/</p2.repo.virsat.url>
 				<p2.repo.overtarget.id>Overtarget-Feature-Integration</p2.repo.overtarget.id>
-				<p2.repo.overtarget.url>https://sourceforge.net/projects/overtarget/files/release/${overtarget.version}/483/</p2.repo.overtarget.url>
+				<p2.repo.overtarget.url>https://sourceforge.net/projects/overtarget/files/release/${overtarget.version}/9014ba468eeed12f9b9624b20bf8feef1f513fdd//</p2.repo.overtarget.url>
 			</properties>
 		</profile>
 		<profile>
@@ -108,7 +108,7 @@
 				<p2.repo.virsat.id>DVLM-Tools-Feature-Release</p2.repo.virsat.id>
 				<p2.repo.virsat.url>https://sourceforge.net/projects/virtualsatellite/files/VirtualSatellite4-DVLM/release/${build.version}/2ebf0c6c75ba40bdfc379fa2356f19b74c3db491</p2.repo.virsat.url>
 				<p2.repo.overtarget.id>Overtarget-Feature-Release</p2.repo.overtarget.id>
-				<p2.repo.overtarget.url>https://sourceforge.net/projects/overtarget/files/release/${overtarget.version}/483</p2.repo.overtarget.url>
+				<p2.repo.overtarget.url>https://sourceforge.net/projects/overtarget/files/release/${overtarget.version}/9014ba468eeed12f9b9624b20bf8feef1f513fdd/</p2.repo.overtarget.url>
 			</properties>
 		</profile>
 

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -45,8 +45,8 @@
 		<sonar.jacoco.version>0.7.7.201606060606</sonar.jacoco.version>
 
 		<eclipse.simultaneous.release.build>${maven.build.timestamp}</eclipse.simultaneous.release.build>
-		<eclipse.simultaneous.release.name>2022-06 Release</eclipse.simultaneous.release.name>
-		<eclipse.simultaneous.release.repository>http://download.eclipse.org/releases/2022-06/</eclipse.simultaneous.release.repository>
+		<eclipse.simultaneous.release.name>2022-03 Release</eclipse.simultaneous.release.name>
+		<eclipse.simultaneous.release.repository>http://download.eclipse.org/releases/2022-03/</eclipse.simultaneous.release.repository>
 	</properties>
 
 	<profiles>
@@ -216,7 +216,7 @@
 		
 		<repository>
 			<id>github-mylyn-connector-feature</id>
-			<url>https://download.eclipse.org/egit/github/updates-nightly/</url>
+			<url>https://download.eclipse.org/egit/github/updates/</url>
 			<layout>p2</layout>
 		</repository> 
 	</repositories>

--- a/maven/pom.xml
+++ b/maven/pom.xml
@@ -213,6 +213,12 @@
 			<url>https://download.eclipse.org/mylyn/releases/3.25/</url>
 			<layout>p2</layout>
 		</repository> 
+		
+		<repository>
+			<id>github-mylyn-connector-feature</id>
+			<url>https://download.eclipse.org/egit/github/updates/</url>
+			<layout>p2</layout>
+		</repository> 
 	</repositories>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 					<plugin>
 						<groupId>org.eclipse.tycho.extras</groupId>
 						<artifactId>tycho-p2-extras-plugin</artifactId>
-						<version>1.7.0</version>
+						<version>2.6.0</version>
 						<executions>
 							<execution>
 								<phase>prepare-package</phase>


### PR DESCRIPTION
**Merge only after Overtarget release with Migration to Java 11.**
* Changes all Java 1.8 settings to Java-11
* Addes the mylyn repository since it was removed from the eclipse release train
* Upgrades the eclipse version because separating Migration to Java 11 and Eclipse upgrade is painful due to various jarkata plugins available in the newer eclipse target platforms.